### PR TITLE
Add starting components for testing

### DIFF
--- a/.github/workflows/run_ci_tests.yml
+++ b/.github/workflows/run_ci_tests.yml
@@ -1,0 +1,10 @@
+name: test_schema
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests from containers
+        run: bash run_tests_with_containers.sh

--- a/.github/workflows/run_ci_tests.yml
+++ b/.github/workflows/run_ci_tests.yml
@@ -1,4 +1,4 @@
-name: test_schema
+name: test_analysis
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/run_ci_tests.yml
+++ b/.github/workflows/run_ci_tests.yml
@@ -1,5 +1,5 @@
 name: test_analysis
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/differential/diffAtlas_DE_limma.R
+++ b/differential/diffAtlas_DE_limma.R
@@ -679,7 +679,8 @@ run_one_colour_analysis <- function( expAcc, allAnalytics, atlasProcessingDirect
 			# Create filenames to write to.
 			# Stats results:
 			resFile <- paste( expAcc, contrastID, "analytics", "tsv", sep = "." )
-			resFile <- file.path( Sys.getenv( "HOME" ), "tmp", resFile )
+			cat(paste("Value of HOME is", Sys.getenv( "HOME" )))
+            resFile <- file.path( Sys.getenv( "HOME" ), "tmp", resFile )
 			# Data for MvA plot:
 			plotDataFile <- paste( expAcc, contrastID, "plotdata", "tsv", sep = "." )
 			plotDataFile <- file.path( Sys.getenv( "HOME" ), "tmp", plotDataFile )

--- a/differential/diffAtlas_DE_limma.R
+++ b/differential/diffAtlas_DE_limma.R
@@ -679,8 +679,7 @@ run_one_colour_analysis <- function( expAcc, allAnalytics, atlasProcessingDirect
 			# Create filenames to write to.
 			# Stats results:
 			resFile <- paste( expAcc, contrastID, "analytics", "tsv", sep = "." )
-			cat(paste("Value of HOME is", Sys.getenv( "HOME" )))
-            resFile <- file.path( Sys.getenv( "HOME" ), "tmp", resFile )
+			resFile <- file.path( Sys.getenv( "HOME" ), "tmp", resFile )
 			# Data for MvA plot:
 			plotDataFile <- paste( expAcc, contrastID, "plotdata", "tsv", sep = "." )
 			plotDataFile <- file.path( Sys.getenv( "HOME" ), "tmp", plotDataFile )

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -3,4 +3,4 @@
 docker run \
   -v $(pwd):/usr/local/ \
   --entrypoint=/usr/local/tests/run-tests.bats \
-  quay.io/ebigxa/atlas-analysis-base:0.0.1
+  quay.io/ebigxa/atlas-analysis-base:latest

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 docker run \
-  -v $(pwd)/tests:/usr/local/tests \
+  -v $(pwd):/usr/local/ \
   --entrypoint=/usr/local/tests/run-tests.bats \
   quay.io/ebigxa/atlas-analysis-base:0.0.1

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker run \
+  -v $(pwd)/tests:/usr/local/tests \
+  --entrypoint=/usr/local/tests/run-tests.bats \
+  quay.io/ebigxa/atlas-analysis-base:0.0.1

--- a/tests/data/differential/microarray/experiments/E-GEOD-11166/E-GEOD-11166-configuration.xml
+++ b/tests/data/differential/microarray/experiments/E-GEOD-11166/E-GEOD-11166-configuration.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration experimentType="microarray_1colour_mrna_differential" r_data="1">
+    <analytics>
+        <array_design>A-AFFY-44</array_design>
+        <assay_groups>
+            <assay_group id="g1" label="deceased donor; 0 month">
+                <assay>GSM281417</assay>
+                <assay>GSM281406</assay>
+                <assay>GSM281421</assay>
+                <assay>GSM281422</assay>
+                <assay>GSM281424</assay>
+                <assay>GSM281356</assay>
+                <assay>GSM281400</assay>
+                <assay>GSM281407</assay>
+                <assay>GSM281420</assay>
+                <assay>GSM281405</assay>
+                <assay>GSM281402</assay>
+                <assay>GSM281403</assay>
+                <assay>GSM281408</assay>
+            </assay_group>
+            <assay_group id="g2" label="deceased donor; 12 month">
+                <assay>GSM281638</assay>
+                <assay>GSM281438</assay>
+                <assay>GSM281632</assay>
+                <assay>GSM281634</assay>
+            </assay_group>
+            <assay_group id="g3" label="deceased donor; 3 month">
+                <assay>GSM281635</assay>
+                <assay>GSM281636</assay>
+                <assay>GSM281646</assay>
+            </assay_group>
+            <assay_group id="g4" label="deceased donor; 6 month">
+                <assay>GSM281657</assay>
+                <assay>GSM281633</assay>
+                <assay>GSM281655</assay>
+            </assay_group>
+            <assay_group id="g5" label="living donor; 0 month">
+                <assay>GSM281259</assay>
+                <assay>GSM281411</assay>
+                <assay>GSM281352</assay>
+                <assay>GSM281276</assay>
+                <assay>GSM281413</assay>
+                <assay>GSM281357</assay>
+                <assay>GSM281410</assay>
+                <assay>GSM281277</assay>
+                <assay>GSM281416</assay>
+                <assay>GSM281346</assay>
+                <assay>GSM281351</assay>
+                <assay>GSM281084</assay>
+                <assay>GSM281414</assay>
+                <assay>GSM281347</assay>
+            </assay_group>
+            <assay_group id="g6" label="living donor; 12 month">
+                <assay>GSM281642</assay>
+                <assay>GSM281664</assay>
+                <assay>GSM281432</assay>
+                <assay>GSM281442</assay>
+                <assay>GSM281429</assay>
+                <assay>GSM281441</assay>
+                <assay>GSM281428</assay>
+                <assay>GSM281637</assay>
+                <assay>GSM281439</assay>
+                <assay>GSM281436</assay>
+                <assay>GSM281425</assay>
+                <assay>GSM281427</assay>
+                <assay>GSM281435</assay>
+                <assay>GSM281440</assay>
+                <assay>GSM281652</assay>
+            </assay_group>
+            <assay_group id="g7" label="living donor; 24 month">
+                <assay>GSM281415</assay>
+                <assay>GSM281401</assay>
+                <assay>GSM281359</assay>
+                <assay>GSM281419</assay>
+                <assay>GSM281409</assay>
+                <assay>GSM281430</assay>
+                <assay>GSM281412</assay>
+                <assay>GSM281398</assay>
+                <assay>GSM281433</assay>
+                <assay>GSM281423</assay>
+                <assay>GSM281418</assay>
+                <assay>GSM281354</assay>
+            </assay_group>
+            <assay_group id="g8" label="living donor; 3 month">
+                <assay>GSM281670</assay>
+                <assay>GSM281650</assay>
+                <assay>GSM281668</assay>
+                <assay>GSM281437</assay>
+                <assay>GSM281431</assay>
+                <assay>GSM281673</assay>
+                <assay>GSM281669</assay>
+                <assay>GSM281654</assay>
+                <assay>GSM281426</assay>
+                <assay>GSM281667</assay>
+                <assay>GSM281085</assay>
+                <assay>GSM281656</assay>
+                <assay>GSM281671</assay>
+                <assay>GSM281672</assay>
+            </assay_group>
+            <assay_group id="g9" label="living donor; 6 month">
+                <assay>GSM281653</assay>
+                <assay>GSM281645</assay>
+                <assay>GSM281640</assay>
+                <assay>GSM281666</assay>
+                <assay>GSM281649</assay>
+                <assay>GSM281644</assay>
+                <assay>GSM281648</assay>
+                <assay>GSM281647</assay>
+                <assay>GSM281665</assay>
+                <assay>GSM281651</assay>
+                <assay>GSM281643</assay>
+                <assay>GSM281434</assay>
+            </assay_group>
+        </assay_groups>
+        <contrasts>
+            <contrast id="g1_g3" cttv_primary="0">
+                <name>'3 month' vs '0 month' in 'deceased donor'</name>
+                <reference_assay_group>g1</reference_assay_group>
+                <test_assay_group>g3</test_assay_group>
+            </contrast>
+            <contrast id="g1_g4" cttv_primary="0">
+                <name>'6 month' vs '0 month' in 'deceased donor'</name>
+                <reference_assay_group>g1</reference_assay_group>
+                <test_assay_group>g4</test_assay_group>
+            </contrast>
+            <contrast id="g1_g2" cttv_primary="0">
+                <name>'12 month' vs '0 month' in 'deceased donor'</name>
+                <reference_assay_group>g1</reference_assay_group>
+                <test_assay_group>g2</test_assay_group>
+            </contrast>
+            <contrast id="g5_g8" cttv_primary="0">
+                <name>'3 month' vs '0 month' in 'living donor'</name>
+                <reference_assay_group>g5</reference_assay_group>
+                <test_assay_group>g8</test_assay_group>
+            </contrast>
+            <contrast id="g5_g9" cttv_primary="0">
+                <name>'6 month' vs '0 month' in 'living donor'</name>
+                <reference_assay_group>g5</reference_assay_group>
+                <test_assay_group>g9</test_assay_group>
+            </contrast>
+            <contrast id="g5_g6" cttv_primary="0">
+                <name>'12 month' vs '0 month' in 'living donor'</name>
+                <reference_assay_group>g5</reference_assay_group>
+                <test_assay_group>g6</test_assay_group>
+            </contrast>
+            <contrast id="g5_g7" cttv_primary="0">
+                <name>'24 month' vs '0 month' in 'living donor'</name>
+                <reference_assay_group>g5</reference_assay_group>
+                <test_assay_group>g7</test_assay_group>
+            </contrast>
+        </contrasts>
+    </analytics>
+</configuration>

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -7,7 +7,7 @@ setup() {
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
 
-    array_diff_script="differential/diffAtlas_DE_limma.R"
+    array_diff_script="$(pwd)/differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"
     array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
     array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -3,21 +3,20 @@
 # Extract the test data
 
 setup() {
-    test_dir='tests'
+    test_dir="${BATS_TEST_DIRNAME}"
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
 
-    array_diff_script="${BATS_TEST_DIRNAME}/../differential/diffAtlas_DE_limma.R"
+    array_diff_script="${test_dir}/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"
-    array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
+    array_diff_exp_dir="${data_dir}/differential/microarray/experiments/E-GEOD-11166/"
     array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"
 
-    if [ ! -d "$output_dir" ]; then
+    if [ ! -d "${output_dir}/tmp" ]; then
         mkdir -p ${output_dir}/tmp
     fi
     
     export HOME=$output_dir
-    cd $test_dir
 }
 
 @test "Run a differential gene expression analysis (1 color microarray)" {

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -7,7 +7,7 @@ setup() {
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
 
-    array_diff_script="$(pwd)/differential/diffAtlas_DE_limma.R"
+    array_diff_script="$(pwd)/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"
     array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
     array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -6,9 +6,8 @@ setup() {
     test_dir='tests'
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
-    script_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-    array_diff_script="${script_dir}/../differential/diffAtlas_DE_limma.R"
+    array_diff_script="${BATS_TEST_DIRNAME}/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"
     array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
     array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# Extract the test data
+
+setup() {
+    test_dir='tests'
+    data_dir="${test_dir}/data"
+    output_dir="${test_dir}/outputs"
+
+    array_diff_script="differential/diffAtlas_DE_limma.R"
+    array_diff_exp="E-GEOD-11166"
+    array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
+    array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"
+
+    if [ ! -d "$output_dir" ]; then
+        mkdir -p ${output_dir}/tmp
+    fi
+    
+    export HOME=$output_dir
+    export PATH=$(pwd):$(pwd)/differential
+    cd $test_dir
+}
+
+@test "Run a differential gene expression analysis (1 color microarray)" {
+    if  [ "$resume" = 'true' ] && [ -f "$array_diff_exp_result" ]; then
+        skip "$array_diff_exp_result exists"
+    fi
+
+    run rm -rf $array_diff_exp_result && $array_diff_script $array_diff_exp $array_diff_exp_dir
+
+    [ "$status" -eq 0 ]
+    [ -f "$array_diff_exp_result" ]
+}

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -5,7 +5,7 @@
 setup() {
     test_dir="${BATS_TEST_DIRNAME}"
     data_dir="${test_dir}/data"
-    output_dir="/tmp"
+    output_dir="${TMPDIR}"
 
     array_diff_script="${test_dir}/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -17,7 +17,6 @@ setup() {
     fi
     
     export HOME=$output_dir
-    export PATH=$(pwd):$(pwd)/differential
     cd $test_dir
 }
 

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -6,8 +6,9 @@ setup() {
     test_dir='tests'
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
+    script_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-    array_diff_script="$(pwd)/../differential/diffAtlas_DE_limma.R"
+    array_diff_script="${script_dir}/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"
     array_diff_exp_dir="data/differential/microarray/experiments/E-GEOD-11166/"
     array_diff_exp_result="${output_dir}/tmp/E-GEOD-11166.g1_g2.analytics.tsv"

--- a/tests/run-tests.bats
+++ b/tests/run-tests.bats
@@ -5,7 +5,7 @@
 setup() {
     test_dir="${BATS_TEST_DIRNAME}"
     data_dir="${test_dir}/data"
-    output_dir="${test_dir}/outputs"
+    output_dir="/tmp"
 
     array_diff_script="${test_dir}/../differential/diffAtlas_DE_limma.R"
     array_diff_exp="E-GEOD-11166"


### PR DESCRIPTION
This PR establishes the containerised testing framework for atlas-analysis following the template of @pcm32 's atlas-schemas, with a templated base container for dependencies. 

More tests will be added in future PRs.