### PR TITLE
Remove Inf values from from TPM transcripts

### DIFF
--- a/transcripts_expr_values_check.R
+++ b/transcripts_expr_values_check.R
@@ -27,6 +27,9 @@ check_file_exists(transExprRawFileName)
 fread(input = transExprTpmFileName) -> TPMexpr
 fread(input = transExprRawFileName) -> Rawexpr
 
+# if any Inf exists in TPMs convert to NA
+for (j in 1:ncol(TPMexpr)) set(TPMexpr, which(is.infinite(TPMexpr[[j]])), j, NA)
+                 
 # if any NA exists in TPMs
 if (any(is.na(TPMexpr))) {
 
@@ -38,11 +41,19 @@ if (any(is.na(TPMexpr))) {
 
         # replace NAs with 0
         TPMexpr[is.na(TPMexpr)] <- 0
+        
+        # if any non-numeric column
+        if ( all(sapply(TPMexpr[,2:ncol(TPMexpr)], function(x){  is.numeric(x) })) == FALSE ){
+            print( "WARNING - at least one column has non-numeric values" ) 
+        }
+        
+        # if all zeros
+        if ( all( sapply(TPMexpr[,2:ncol(TPMexpr)], function(x){ (all(x==0)  ) } )) ){
+            print( "WARNING - all elements in the matrix are 0" ) 
+        }
 
         # export TPM transcript file
         fwrite(TPMexpr, file = transExprTpmFileName, row.names = FALSE, quote = FALSE, sep = "\t")
     }
 }
-
-# if any Inf exists in TPMs
 

--- a/transcripts_expr_values_check.R
+++ b/transcripts_expr_values_check.R
@@ -14,7 +14,7 @@ transExprTpmFileName <- args[1]
 transExprRawFileName <- args[2]
 
 
-## file checks
+# file checks
 check_file_exists <- function(filename) {
     if (!file.exists(filename)) {
         stop(paste("Cannot find:", filename))
@@ -43,3 +43,6 @@ if (any(is.na(TPMexpr))) {
         fwrite(TPMexpr, file = transExprTpmFileName, row.names = FALSE, quote = FALSE, sep = "\t")
     }
 }
+
+# if any Inf exists in TPMs
+

--- a/transcripts_expr_values_check.R
+++ b/transcripts_expr_values_check.R
@@ -43,8 +43,9 @@ if (any(is.na(TPMexpr))) {
         TPMexpr[is.na(TPMexpr)] <- 0
         
         # if any non-numeric column
-        if ( all(sapply(TPMexpr[,2:ncol(TPMexpr)], function(x){  is.numeric(x) })) == FALSE ){
-            print( "WARNING - at least one column has non-numeric values" ) 
+        if ( all(sapply(TPMexpr[,2:ncol(TPMexpr)], function(x){ is.numeric(x) })) == FALSE ){
+            print( "ERROR - at least one column has non-numeric values" )
+            quit( save = "no", status = 1, runLast = FALSE )
         }
         
         # if all zeros


### PR DESCRIPTION
The current implementation of `transcripts_expr_values_check.R` resolve problem with NAs, but not with Infinites.

In addition, I have added a couple of extra checks