### PR TITLE
L267 - Error $arrayDataTech not found for $arrayDesign 

### DIFF
--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -284,6 +284,9 @@ sub make_arrays_to_factors_to_files {
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
 			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+		}elsif($exptAccession eq "E-CURD-61" || $exptAccession eq "E-CURD-63"){
+			print("Not included in bioStudies \n");
+			$arrayDataTech="Affymetrix";
 		}else{
    			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 		}

--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -279,8 +279,13 @@ sub make_arrays_to_factors_to_files {
 		# Get the raw data filename
 		my $arrayDataFile = File::Spec->catfile( $loadDir, $assay4atlas->get_array_data_file );
 
-        # Get technology from Array design file using BioStudies API 
-        my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+        	# Get technology from Array design file using BioStudies API 
+		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
+   			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
+			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+		}else{
+   			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+		}
 
 		# For 1-colour array data, need to tell the R script whether this is
 		# Affymetrix or Agilent (or other -- for now we only handle Affy and Agil

--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -280,6 +280,7 @@ sub make_arrays_to_factors_to_files {
 		my $arrayDataFile = File::Spec->catfile( $loadDir, $assay4atlas->get_array_data_file );
 
         	# Get technology from Array design file using BioStudies API 
+		my $arrayDataTech = "";
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
 			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
@@ -303,6 +304,7 @@ sub make_arrays_to_factors_to_files {
 		} elsif($experimentType eq "two-colour array") {
 			$experimentType = "agil2";
 		}
+		print $experimentType;
 
 		# Push all factor values onto an array.
 		my @factorValues = ();

--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -283,9 +283,9 @@ sub make_arrays_to_factors_to_files {
 		my $arrayDataTech = "";
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
-			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
 		}else{
-   			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+   			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 		}
 
 		# For 1-colour array data, need to tell the R script whether this is

--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -279,9 +279,8 @@ sub make_arrays_to_factors_to_files {
 		# Get the raw data filename
 		my $arrayDataFile = File::Spec->catfile( $loadDir, $assay4atlas->get_array_data_file );
 
-        # Get technology from Array design file using peach API. 
-        my $adfInfoUrl = $atlasSiteConfig->get_arrayexpress_adf_info_url;
-        my $arrayDataTech=`curl -s $adfInfoUrl$arrayDesign`;
+        # Get technology from Array design file using BioStudies API 
+        my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 
 		# For 1-colour array data, need to tell the R script whether this is
 		# Affymetrix or Agilent (or other -- for now we only handle Affy and Agil

--- a/arrays/arrayQC.pl
+++ b/arrays/arrayQC.pl
@@ -307,7 +307,7 @@ sub make_arrays_to_factors_to_files {
 		} elsif($experimentType eq "two-colour array") {
 			$experimentType = "agil2";
 		}
-		print $experimentType;
+		print $experimentType "\t$arrayDesign\n";
 
 		# Push all factor values onto an array.
 		my @factorValues = ();

--- a/arrays/highestMeanProbeIdsPerGene.R
+++ b/arrays/highestMeanProbeIdsPerGene.R
@@ -18,7 +18,7 @@ if( !grepl( "-normalized-expressions.tsv.decorated.tmp$", expNormFileName ) ) {
 
 findHighestMeanProbePerGene<-function( expNormFileName ) {
    
-  fread(input=expNormFileName)->exprWAnnot
+  fread(input=expNormFileName, header=TRUE, check.names=FALSE)->exprWAnnot
   
   exprWAnnot$mean<-rowMeans(exprWAnnot[,4:ncol(exprWAnnot)])
   

--- a/arrays/highestMeanProbeIdsPerGene.R
+++ b/arrays/highestMeanProbeIdsPerGene.R
@@ -18,7 +18,8 @@ if( !grepl( "-normalized-expressions.tsv.decorated.tmp$", expNormFileName ) ) {
 
 findHighestMeanProbePerGene<-function( expNormFileName ) {
    
-  fread(input=expNormFileName, header=TRUE, check.names=FALSE)->exprWAnnot
+  #fread(input=expNormFileName, header=TRUE, check.names=FALSE)->exprWAnnot
+  fread(input=expNormFileName)->exprWAnnot
   
   exprWAnnot$mean<-rowMeans(exprWAnnot[,4:ncol(exprWAnnot)])
   

--- a/norm/arrayNormalization.R
+++ b/norm/arrayNormalization.R
@@ -165,8 +165,11 @@ agilentArray <- function(files, mode, assayNames, outFile, miRBaseFile) {
 
 affymetrixArray <- function(files, assayNames, outFile) {
 
-	# Load oligo
 	library(oligo)
+	
+	print( files )
+	print( assayNames )
+	print( outFile )
 
 	# Read in data from CEL files using read.celfiles().
 	# read.celfiles() creates a Biobase object whose class varies

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -250,6 +250,7 @@ sub makeArraysToAssaysToFiles {
 		}
 
 		# Get technology from Array design file using peach API. 
+		#
 		my $adfInfoUrl = $atlasSiteConfig->get_arrayexpress_adf_info_url;
 		my $arrayDataTech=`curl -s $adfInfoUrl$arrayDesign`;
 

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -249,8 +249,7 @@ sub makeArraysToAssaysToFiles {
 			next;
 		}
 
-		# Get technology from Array design file using BioStudies API. 
-		# NB: This is a bit of a hack, but it's the only way to get the technology
+		# Get technology from Array design file using biostudies API. 
 		my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 
 		# Raw data filename.

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -254,6 +254,9 @@ sub makeArraysToAssaysToFiles {
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
 			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+		}elsif($exptAccession eq "E-CURD-61" || $exptAccession eq "E-CURD-63"){
+			print("Not included in bioStudies \n");
+			$arrayDataTech="Affymetrix";
 		}else{
    			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 		}

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -253,9 +253,9 @@ sub makeArraysToAssaysToFiles {
 		my $arrayDataTech = "";
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
-			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
 		}else{
-   			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+   			$arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 		}
 
 		# Raw data filename.

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -250,7 +250,12 @@ sub makeArraysToAssaysToFiles {
 		}
 
 		# Get technology from Array design file using biostudies API. 
-		my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
+   			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
+			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
+		}else{
+   			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
+		}
 
 		# Raw data filename.
 		my $arrayDataFile = File::Spec->catfile( $loadDir, $assay4atlas->get_array_data_file );

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -249,10 +249,9 @@ sub makeArraysToAssaysToFiles {
 			next;
 		}
 
-		# Get technology from Array design file using peach API. 
-		#
-		my $adfInfoUrl = $atlasSiteConfig->get_arrayexpress_adf_info_url;
-		my $arrayDataTech=`curl -s $adfInfoUrl$arrayDesign`;
+		# Get technology from Array design file using BioStudies API. 
+		# NB: This is a bit of a hack, but it's the only way to get the technology
+		my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/$exptAccession`;
 
 		# Raw data filename.
 		my $arrayDataFile = File::Spec->catfile( $loadDir, $assay4atlas->get_array_data_file );

--- a/norm/arrayNormalization.pl
+++ b/norm/arrayNormalization.pl
@@ -250,6 +250,7 @@ sub makeArraysToAssaysToFiles {
 		}
 
 		# Get technology from Array design file using biostudies API. 
+		my $arrayDataTech = "";
 		if($exptAccession eq "E-CURD-50" || $exptAccession eq "E-CURD-51"){
    			print("BioStudies E-MTAB-800 was split into E-CURD-50 and E-CURD-51 \n");
 			my $arrayDataTech=`curl -s https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-800`;
@@ -270,12 +271,13 @@ sub makeArraysToAssaysToFiles {
 			else {
 				$logger->logdie( "Error $arrayDataTech not found for $arrayDesign " )
 			}
-			} elsif( $experimentType =~ /2colour/ ) {
-				$normalizationMode = "agil2";
-
+		} elsif( $experimentType =~ /2colour/ ) {
+			$normalizationMode = "agil2";
+			
 			# Remove label name from assay name which was added by Atlas::Magetab4Atlas.
 			$assayName =~ s/\.Cy\d$//;
 		}
+		print $normalizationMode;
 
 		# Add data to hash.
 		$H_arraysToAssaysToFiles->{ $arrayDesign }->{ $assayName } = $arrayDataFile;

--- a/qc/rnaseqQC.pl
+++ b/qc/rnaseqQC.pl
@@ -153,7 +153,7 @@ foreach my $row ( @resultsRows ) {
 	my @splitRow = split /\t/, $row;
 
 	my $runAcc = $splitRow[ 1 ];
-	my $qcStatus = $splitRow[ 5 ];
+	my $qcStatus = $splitRow[ 6 ];
 
     	# Save the run accession.
     	$qcRuns->{ $runAcc } = 1;
@@ -168,7 +168,7 @@ foreach my $row ( @resultsRows ) {
 
         # Also see if we got less than 70% reads mapped. If so, add them to
         # the hash to save them.
-        my $percentMappedReads = $splitRow[ 6 ];
+        my $percentMappedReads = $splitRow[ 7 ];
 
         if( $percentMappedReads < 70 ) {
 

--- a/qc/rnaseqQC.pl
+++ b/qc/rnaseqQC.pl
@@ -153,7 +153,7 @@ foreach my $row ( @resultsRows ) {
 	my @splitRow = split /\t/, $row;
 
 	my $runAcc = $splitRow[ 1 ];
-	my $qcStatus = $splitRow[ 6 ];
+	my $qcStatus = $splitRow[ 5 ];
 
     	# Save the run accession.
     	$qcRuns->{ $runAcc } = 1;
@@ -168,7 +168,7 @@ foreach my $row ( @resultsRows ) {
 
         # Also see if we got less than 70% reads mapped. If so, add them to
         # the hash to save them.
-        my $percentMappedReads = $splitRow[ 7 ];
+        my $percentMappedReads = $splitRow[ 6 ];
 
         if( $percentMappedReads < 70 ) {
 

--- a/qc/rnaseqQC.pl
+++ b/qc/rnaseqQC.pl
@@ -155,8 +155,8 @@ foreach my $row ( @resultsRows ) {
 	my $runAcc = $splitRow[ 1 ];
 	my $qcStatus = $splitRow[ 6 ];
 
-    # Save the run accession.
-    $qcRuns->{ $runAcc } = 1;
+    	# Save the run accession.
+    	$qcRuns->{ $runAcc } = 1;
 
 	# Skip if this run is not in the experiment config.
 	unless( $configRuns->{ $runAcc } ) { next; }

--- a/qc/rnaseqQC.pl
+++ b/qc/rnaseqQC.pl
@@ -86,6 +86,8 @@ unless( can_run( $islResultsScript ) ) {
 	);
 }
 
+$logger->info( "isl results script is $islResultsScript" );
+
 my $atlasXMLfile = "$expAcc-configuration.xml";
 
 unless( -r $atlasXMLfile ) {


### PR DESCRIPTION
Processing of new microarrays is failing due to `$arrayDataTech` not being defined due the deprecation of Peach API

Changes necessary here:
- norm/arrayNormalization.pl
- arrays/arrayQC.pl

 In the past, microarray designs (e.g. A-MEXP-2320 ) were obtained querying the Peach API curl. Now it needs to be done using Biostudies
```
curl https://www.ebi.ac.uk/biostudies/api/v1/studies/E-MTAB-8600
```

Also, I've edit fread function in `highestMeanProbeIdsPerGene.R` so when we have numeric column names (yes, it happens) R does not modify them.