### PR TITLE
Do not modify GTEX column names

### DIFF
--- a/norm/gxa_quantileNormalization.R
+++ b/norm/gxa_quantileNormalization.R
@@ -17,6 +17,7 @@ check_file_exists <- function( filename ) {
     }
 }
 
+
 # Get command line arguments -- filename for input and filename for output.
 args <- commandArgs( TRUE )
 
@@ -53,8 +54,15 @@ assayGroupMappingsList <- lapply( assayGroups, function( assayGroup ) {
     # Get the row indices of this assay group in the data frame.
     rowIndices <- which( assayGroupMappingsDF$AssayGroupID == assayGroup )
 
-    # Return the column headings at those row indices.
-    make.names( assayGroupMappingsDF$ColumnHeading[ rowIndices ] )
+    
+    # Get the column headings at those row indices
+    columnHeadings <- assayGroupMappingsDF$ColumnHeading[rowIndices]
+    # Sanitize the column headings if they do not contain "GTEX"
+    if(any(!grepl("GTEX", columnHeadings))) {
+        columnHeadings <- make.names( columnHeadings )
+    }
+    return(columnHeadings)
+    
 })
 
 # Create a list of data frames containing normalized data, one data frame for


### PR DESCRIPTION
For the analysis of controlled-access GTEX-8 we have 

```
> make.names("GTEX-13111-0326-SM-5DUXF")
[1] "GTEX.13111.0326.SM.5DUXF"
```
This function in R is used to ensure that the column headings are syntactically valid names. If any character in the original column heading is not valid for a variable name in R, it will be replaced by ".". So if any of your column headings contain "-", they will be replaced by "." implicitly in this step.

This PR will avoid this, as all GTEX libraries have the form of "GTEX-..."

