### PR TITLE
Handle NA values in GENE_NAME column

### DIFF
--- a/baselinemarkers/get_marker_genes_proteomics.R
+++ b/baselinemarkers/get_marker_genes_proteomics.R
@@ -359,7 +359,7 @@ final_df <- final_df %>%
     left_join(expression_decorated %>% select(GENE_ID = Gene.ID, GENE_NAME = Gene.Name),
               by = "GENE_ID")
 
-
+final_df$GENE_NAME[is.na(final_df$GENE_NAME)] <- ""
 
 # Ensure EXPRESSION is numeric
 final_df$EXPRESSION <- NA_real_

--- a/baselinemarkers/get_marker_genes_rnaseq.R
+++ b/baselinemarkers/get_marker_genes_rnaseq.R
@@ -300,7 +300,7 @@ final_df <- final_df %>%
     left_join(expression_decorated %>% select(GENE_ID = GeneID, GENE_NAME = Gene.Name),
               by = "GENE_ID")
 
-
+final_df$GENE_NAME[is.na(final_df$GENE_NAME)] <- ""
 
 head(final_df)
 dim(final_df)


### PR DESCRIPTION
Fixes following bugs 

- [x] Handle NA values in GENE_NAME column
`na` becomes `NA` in file and then database which creates issue of showing NA is gene name. An empty cell/field will force webapp to look into Gene IDs